### PR TITLE
improv/a11y-plus-styling-container: directly apply aria roles and lab…

### DIFF
--- a/src/js/labels/labels.js
+++ b/src/js/labels/labels.js
@@ -1,0 +1,4 @@
+export const nouns = {
+    AUDIO_PLAYER: () => 'audio player',
+    VIDEO_PLAYER: () => 'video player',
+};

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -10,6 +10,7 @@
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import { Window as window, Document as document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
+import { nouns } from './labels/labels.js';
 
 const template = document.createElement('template');
 
@@ -181,6 +182,12 @@ class MediaContainer extends window.HTMLElement {
   }
 
   connectedCallback() {
+    
+    const isAudioChrome = this.getAttribute('audio') != null;
+    const label = isAudioChrome ? nouns.AUDIO_PLAYER() : nouns.VIDEO_PLAYER();
+    this.setAttribute('role', 'region')
+    this.setAttribute('aria-label', label);
+
     if (this.media) {
       this.mediaSetCallback(this.media);
     }


### PR DESCRIPTION
…els to container/controller custom element to make custom styling easier.

Instead of adding a semantic html element (`<section/>`) as a root child of the `<media-container/>`/`<media-controller/>` custom element, we should apply a11y-related attributes to the custom element itself, primarily to make customization of styling and the like easier for implementors.

Confirmed:
- [x] No errors reported related to this approach from axe Chrome extension audit
- [x] No errors reported related to this approach from built-in Chrome Lighthouse dev tool audit
- [x] Works as expected with macOS VoiceOver
- [x] Layout of examples/themes/spotify-theme.html still rendered as expected